### PR TITLE
Adds `display` property to generated css files

### DIFF
--- a/tmpl/css/sprite.css
+++ b/tmpl/css/sprite.css
@@ -1,10 +1,12 @@
 {{#common}}.{{mixin}} {
+	display: inline-block;
 	background-repeat: no-repeat;
 	background-image: url({{{sprite}}});
 }
 
 {{/common}}{{#shapes}}{{#selector.shape}}{{expression}}{{^last}},
 {{/last}}{{/selector.shape}} {
+	display: inline-block;
 	background-position: {{position.relative.xy}};{{^common}}
 	background-repeat: no-repeat;
 	background-image: url({{{sprite}}});{{/common}}{{#dimensions.inline}}

--- a/tmpl/css/sprite.less
+++ b/tmpl/css/sprite.less
@@ -1,4 +1,5 @@
 .{{mixin}}{{^common}}(){{/common}} {
+	display: inline-block;
 	background-repeat: no-repeat;
 	background-image: url({{{sprite}}});
 }

--- a/tmpl/css/sprite.scss
+++ b/tmpl/css/sprite.scss
@@ -1,4 +1,5 @@
 {{#common}}.{{/common}}{{^common}}%{{/common}}{{mixin}} {
+	display: inline-block;
 	background-repeat: no-repeat;
 	background-image: url({{{sprite}}});
 }

--- a/tmpl/css/sprite.styl
+++ b/tmpl/css/sprite.styl
@@ -1,4 +1,5 @@
 {{#common}}.{{/common}}{{^common}}${{/common}}{{mixin}} 
+	display: inline-block;
 	background-repeat no-repeat
 	background-image url({{{sprite}}})
 

--- a/tmpl/view/sprite.html
+++ b/tmpl/view/sprite.html
@@ -18,6 +18,7 @@ This is an all-in-one inline version of the CSS necessary to use the SVG sprite.
 <style type="text/css">
 {{#shapes}}{{#selector.shape}}.{{#classname}}{{expression}}{{/classname}}{{^last}},
 {{/last}}{{/selector.shape}} {
+	display: inline-block;
 	background-position: {{position.relative.xy}};
 	background-repeat: no-repeat;
 	background-image: url({{{sprite}}});


### PR DESCRIPTION
This should make sprites usable out of the box, without additional css tinkering.