### PR TITLE
Remove "." (dot). Selector already has one.

### DIFF
--- a/tmpl/symbol/sprite.html
+++ b/tmpl/symbol/sprite.html
@@ -18,7 +18,7 @@ They might well be outsourced to an external stylesheet of course.
 -->
 
 <style type="text/css">
-{{#shapes}}	.{{#selector.dimensions}}{{expression}}{{^last}}, {{/last}}{{/selector.dimensions}} { width: {{width.outer}}px; height: {{height.outer}}px; }
+{{#shapes}}	{{#selector.dimensions}}{{expression}}{{^last}}, {{/last}}{{/selector.dimensions}} { width: {{width.outer}}px; height: {{height.outer}}px; }
 {{/shapes}}</style>
 <!--
 ====================================================================================================


### PR DESCRIPTION
Configuration field 'prefix' should contain first selector parts including class dot. To prevent duplication we remove one from template. 
https://github.com/jkphl/svg-sprite/blob/master/docs/configuration.md#common-mode-properties