### PR TITLE
Problem when dimensions are not rounded properly

### DIFF
--- a/lib/svg-sprite/shape.js
+++ b/lib/svg-sprite/shape.js
@@ -475,8 +475,8 @@ SVGShape.prototype._determineDimensions = function(cb) {
 	
 	// Try to use a viewBox attribute for image determination
 	if (this.viewBox !== false) {
-		this.width				= this.viewBox[2];
-		this.height				= this.viewBox[3];
+		this.width				= this._round(this.viewBox[2]);
+		this.height				= this._round(this.viewBox[3]);
 	}
 
 	// If the viewBox attribute didn't suffice: Render the SVG image
@@ -487,8 +487,8 @@ SVGShape.prototype._determineDimensions = function(cb) {
 	            cb(err);
 	        } else if (stdout.length > 0) { // PhantomJS always outputs to stdout.
 	        	var dimensions	= JSON.parse(stdout.toString().trim());
-	        	that.width		= dimensions.width;
-	        	that.height		= dimensions.height;
+	        	that.width		= that._round(dimensions.width);
+	        	that.height		= that._round(dimensions.height);
 	        	cb(null);
 	        } else if (stderr.length > 0) {
 	            cb(new Error(stderr.toString().trim()));


### PR DESCRIPTION
I noticed the problem by adding precision `0` to the `shape.dimension`. The values were not rounded in the stylesheet. Then I looked around and it appeared that when the values are coming from the bounding box or from phantomjs they are not rounded at all. 

When loading the style into chrome I had issues with some svgs which were slightly taller. I get that the svgs should never have a width/height with decimals precision, but the plugin should also handle that.
