### PR TITLE
Change phantomjs into phantomjs-prebuild

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
 		"svgo": "0.6.1",
 		"cssom": "^0.3.0",
 		"css-selector-parser": "^1.1.0",
-		"phantomjs": "^1.9.19",
+		"phantomjs-prebuilt": "^2.1.7",
 		"cssmin": "^0.4.3",
 		"mustache": "^2.2.1",
 		"js-yaml": "^3.5.2",


### PR DESCRIPTION
Hi @jkphl 

I just change the dependency of `phantomjs` into `phantomjs-prebuild`
Because I have random errors on Bitbucket 403 and 429 (too many requests), actually because `phantomjs` is downloading itself or a dependency that they need from a repo on bitbucket and bitbucket are responding with some errors.
and this stuff is breaking my build :cry: 

Source: [phantomjs#deprecated](https://www.npmjs.com/package/phantomjs#deprecated)