### PR TITLE
Fix incorrect lookup for shape-transform-* config

### DIFF
--- a/bin/svg-sprite.js
+++ b/bin/svg-sprite.js
@@ -150,9 +150,9 @@ var transform						= ('' + config.shape.transform).trim();
 config.shape.transform					= [];
 (transform.length ? transform.split(',').map(function(trans){ return ('' + trans).trim(); }) : []).forEach(function(transform){
 	if (transform.length) {
-		if (('transform-' + transform) in argv) {
+		if (('shape-transform-' + transform) in argv) {
 			try {
-				var transformConfigFile		= argv['transform-' + transform],
+				var transformConfigFile		= argv['shape-transform-' + transform],
 				transformConfigJSON			= fs.readFileSync(path.resolve(transformConfigFile), {encoding: 'utf8'}),
 				transformConfig				= transformConfigJSON.trim() ? JSON.parse(transformConfigJSON) : {};
 				this.push(_.zipObject([transform], [transformConfig]));


### PR DESCRIPTION
Documentation states that you can provide transform config json files using the argument "--shape-transform-*". The code actually looks for "--transform-*". Change fixes this to match the documented behaviour.