### PR TITLE
Update sprite.less to avoid compilation error on mixin call

### DIFF
--- a/tmpl/css/sprite.less
+++ b/tmpl/css/sprite.less
@@ -12,7 +12,7 @@
 
 {{/hasMixin}}{{#shapes}}{{#selector.shape}}{{expression}}{{^last}},
 {{/last}}{{/selector.shape}} {
-	{{^hasCommon}}{{#hasMixin}}{{mixinName}}();{{/hasMixin}}{{^hasMixin}}.{{commonName}}();{{/hasMixin}}
+	{{^hasCommon}}.{{#hasMixin}}{{mixinName}}();{{/hasMixin}}{{^hasMixin}}.{{commonName}}();{{/hasMixin}}
 	{{/hasCommon}}background-position: {{position.relative.xy}};{{#dimensions.inline}}
 	width: {{width.outer}}px;
 	height: {{height.outer}}px;{{/dimensions.inline}}

--- a/tmpl/css/sprite.less
+++ b/tmpl/css/sprite.less
@@ -12,7 +12,7 @@
 
 {{/hasMixin}}{{#shapes}}{{#selector.shape}}{{expression}}{{^last}},
 {{/last}}{{/selector.shape}} {
-	{{^hasCommon}}.{{#hasMixin}}{{mixinName}}();{{/hasMixin}}{{^hasMixin}}.{{commonName}}();{{/hasMixin}}
+	{{^hasCommon}}{{#hasMixin}}.{{mixinName}}();{{/hasMixin}}{{^hasMixin}}.{{commonName}}();{{/hasMixin}}
 	{{/hasCommon}}background-position: {{position.relative.xy}};{{#dimensions.inline}}
 	width: {{width.outer}}px;
 	height: {{height.outer}}px;{{/dimensions.inline}}


### PR DESCRIPTION
Adds a dot before calling the less mixin otherwise this will generate syntax errors.

I'm using the following configuration in grunt-svg-sprite:

```
target: {
		src: '../svgs/*',
		dest: '.',
		options: {
			shape: {
				id: {
					generator: generatorFunc
				},
				dimension: {
					maxWidth: 76,
					maxHeight: 76
				},
				spacing: {
					padding: 1
				}
			},
			mode: {
				css: {
					bust: false,
					mixin: 'svg-mysvgs-common',
					sprite: '../img/Icons',
					prefix: '.myPrefix-',
					dimensions: true,
					render: {
						less: {
							dest: '../src/less/somelessfile.less'
						}
					}
				}
			}
		}
	},
```

will generate something like:
```
.svg-mysvgs-common() {
	background: url("../img/whatever.svg") no-repeat;
}

.myPrefix-some-svg {
	svg-trait-small-common();
	background-position: 16.666666666666668% 0;
	width: 50px;
	height: 50px;
}
```

in the output `svg-trait-small-common()` will cause a less compiler error. It needs the '.' before it.

This looks similar to a previous issue #133 

Thanks so much for the hard work in this library!