### PR TITLE
Fix regexp to handle quotes in url()

### DIFF
--- a/lib/svg-sprite/shape.js
+++ b/lib/svg-sprite/shape.js
@@ -754,7 +754,7 @@ SVGShape.prototype._replaceIdAndClassnameReferences = function(str, substIds, su
 
 	// If ID replacement is to be applied: Replace url()-style ID references
 	if (substIds !== null) {
-    	str = str.replace(/url\s*\(\s*["']?([^\)]+)["']?\s*\)/g, function(match, id){
+    	str = str.replace(/url\s*\(\s*["']?([^\s"'\)]+)["']?\s*\)/g, function(match, id){
     		return 'url(' + ((id in substIds) ? ('#' + substIds[id]) : id) + ')';
     	});
 	}


### PR DESCRIPTION
I had an error that in some cases original `clip-path` attribute is absent in resulting sprite, in particular it's happening for attributes like `clip-path="url('#someID')"`

after debugging turned out that `svg-sprite` incorrectly handles quotes in `url()` - see this [jsbin](http://jsbin.com/bulinidota/edit?js,console)

so here's fix for this issue