### PR TITLE
Allow for array transforms in config file to be passed to CLI

### DIFF
--- a/bin/svg-sprite.js
+++ b/bin/svg-sprite.js
@@ -213,25 +213,27 @@ if (config.svg.rootAttributes) {
 }
 
 // Expand transformation options
-var transform = ('' + config.shape.transform).trim();
-config.shape.transform = [];
-(transform.length ? transform.split(',').map(function (trans) {
-	return ('' + trans).trim();
-}) : []).forEach(function (transform) {
-	if (transform.length) {
-		if (('shape-transform-' + transform) in argv) {
-			try {
-				var transformConfigFile = argv['shape-transform-' + transform],
-					transformConfigJSON = fs.readFileSync(path.resolve(transformConfigFile), {encoding: 'utf8'}),
-					transformConfig = transformConfigJSON.trim() ? JSON.parse(transformConfigJSON) : {};
-				this.push(_.zipObject([transform], [transformConfig]));
-			} catch (e) {
+if (typeof config.shape.transform === 'string') {
+	var transform = ('' + config.shape.transform).trim();
+	config.shape.transform = [];
+	(transform.length ? transform.split(',').map(function (trans) {
+		return ('' + trans).trim();
+	}) : []).forEach(function (transform) {
+		if (transform.length) {
+			if (('shape-transform-' + transform) in argv) {
+				try {
+					var transformConfigFile = argv['shape-transform-' + transform],
+						transformConfigJSON = fs.readFileSync(path.resolve(transformConfigFile), {encoding: 'utf8'}),
+						transformConfig = transformConfigJSON.trim() ? JSON.parse(transformConfigJSON) : {};
+					this.push(_.zipObject([transform], [transformConfig]));
+				} catch (e) {
+				}
+			} else {
+				this.push(transform);
 			}
-		} else {
-			this.push(transform);
 		}
-	}
-}, config.shape.transform);
+	}, config.shape.transform);
+}
 
 // Run through all sprite modes
 ['css', 'view', 'defs', 'symbol', 'stack'].forEach(function (mode) {


### PR DESCRIPTION
According to the docs (https://github.com/jkphl/svg-sprite/blob/master/docs/command-line.md), a config file that's generated from the online config generator can be passed to the CLI. However, passing it the file wasn't able to read the SVGO transform plugins. This is because the CLI tries to do special string processing on the transform configuration.

This PR passes through the `shape.transform` config unless it is a string.

Example config file that was unable to process the svgo plugins:

```
{
  "dest": "dist",
  "shape": {
    "transform": [
      {
        "svgo": {
          "plugins": [
            { "removeUnknownsAndDefaults"    : false}
          ]
        }
      }
    ]
  },
  "mode": {
    "symbol": {
      "dest": ".",
      "sprite": "ui.svg"
    }
  }
}
```