### PR TITLE
Solve issue with showing incorrect month in log

### DIFF
--- a/lib/svg-sprite/config.js
+++ b/lib/svg-sprite/config.js
@@ -94,9 +94,6 @@ function SVGSpriterConfig(config) {
 		}
 	}
 	if (_.isString(this.log)) {
-		var twoDigits					= function(i) {
-			return ('0' + i).slice(-2);
-		};
 		this.log						= new winston.Logger({
 			transports					: [new (winston.transports.Console)({
 				level					: this.log || 'info',
@@ -105,7 +102,7 @@ function SVGSpriterConfig(config) {
 				prettyPrint				: true,
 				timestamp				: function() {
 					var now				= new Date();
-					return now.getFullYear() + '-' + twoDigits(now.getMonth()) + '-' + twoDigits(now.getDate()) + ' ' + twoDigits(now.getHours()) + ':' + twoDigits(now.getMinutes()) + ':' + twoDigits(now.getSeconds());
+					return now.format('Y-m-d H:i:s');
 				}
 			})]
 		});


### PR DESCRIPTION
The `getMonth` method returned a zero-based integer value for the month (see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getMonth), which would therefore be showing 1 month behind what the actual month is.

Example output from today (February 15th) which shows the issue:
![screen shot 2017-02-15 at 15 04 51](https://cloud.githubusercontent.com/assets/2520380/22980034/29cc3ee6-f390-11e6-8d44-72e9f39098a0.png)

The `Date.format` provides the same formatted date which the timestamp method was previously building manually.