### PR TITLE
if shape.id.separator set to false or '' return shape id without file path separator (only filename)

### DIFF
--- a/lib/svg-sprite/shape.js
+++ b/lib/svg-sprite/shape.js
@@ -39,6 +39,9 @@ createIdGenerator			= function(template) {
 	 * @returns {String}			Shape ID
      */
 	var generator = function(name, file) {
+		if ( !this.separator ) {
+			return util.format(template || '%s', path.basename(name.replace(/\s+/g, this.whitespace), '.svg'));
+		}
 		return util.format(template || '%s', path.basename(name.split(path.sep).join(this.separator).replace(/\s+/g, this.whitespace), '.svg'));
 	};
 	return generator;


### PR DESCRIPTION
If user doesn't want to add file path to shape id