### PR TITLE
Use more recent version of svgo

### DIFF
--- a/lib/svg-sprite/transform/svgo.js
+++ b/lib/svg-sprite/transform/svgo.js
@@ -63,19 +63,17 @@ module.exports = function(shape, config, spriter, cb) {
 	svgLength						= svg.length,
 	svgoInstance					= new SVGO(config);
 
-	try {
-		svgoInstance.optimize(svg, function(result) {
-			shape.setSVG(result.data);
+	svgoInstance.optimize(svg).then(function(result) {
+		shape.setSVG(result.data);
 
-			if (spriter.config.log.transports.console.level === 'debug') {
-				var optSVGLength	= shape.getSVG(false).length;
-				spriter.debug('Optimized "%s" with SVGO (saved %s / %s%%)', shape.name, pretty(svgLength - optSVGLength), Math.round(100 * (svgLength - optSVGLength) / svgLength));
-			}
+		if (spriter.config.log.transports.console.level === 'debug') {
+			var optSVGLength	= shape.getSVG(false).length;
+			spriter.debug('Optimized "%s" with SVGO (saved %s / %s%%)', shape.name, pretty(svgLength - optSVGLength), Math.round(100 * (svgLength - optSVGLength) / svgLength));
+		}
 
-			cb(null);
-		});
-	} catch (error) {
+		cb(null);
+	}, function(error) {
 		spriter.error('Optimizing "%s" with SVGO failed with error "%s"', shape.name, error);
 		cb(error);
-	}
+	});
 };

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "mustache": "^2.3.0",
     "phantomjs-prebuilt": "^2.1.14",
     "prettysize": "^0.1.0",
-    "svgo": "^0.7.2",
+    "svgo": "^1.0.4",
     "vinyl": "^2.0.2",
     "winston": "^2.3.1",
     "xmldom": "0.1.27",


### PR DESCRIPTION
The optimize() function now returns a promise. Adapt the code to
behave correctly in this case.

We could also just keep the older svgo dependency.