### PR TITLE
Enforce linting

### DIFF
--- a/bin/svg-sprite.js
+++ b/bin/svg-sprite.js
@@ -245,11 +245,7 @@ if (typeof config.shape.transform === 'string') {
 	// Remove excessive render types
 	['css', 'scss', 'less', 'styl'].forEach(function (render) {
 		var arg = mode + '-render-' + render;
-		if ((render in this) && !argv[arg]
-			&& (!(mode in JSONConfig.mode)
-			|| !('render' in JSONConfig.mode[mode])
-			|| !(render in JSONConfig.mode[mode].render))
-		) {
+		if (render in this && !argv[arg] && (!(mode in JSONConfig.mode) || !('render' in JSONConfig.mode[mode]) || !(render in JSONConfig.mode[mode].render))) {
 			delete this[render];
 		}
 	}, this[mode].render);
@@ -262,10 +258,7 @@ if (typeof config.shape.transform === 'string') {
 // Remove excessive example options
 for (var mode in config.mode) {
 	var example = mode + '-example';
-	if (!argv[example]
-		&& (!(mode in JSONConfig.mode) || !('example' in JSONConfig.mode[mode]))
-		&& ('example' in config.mode[mode])
-	) {
+	if (!argv[example] && (!(mode in JSONConfig.mode) || !('example' in JSONConfig.mode[mode])) && 'example' in config.mode[mode]) {
 		delete config.mode[mode].example;
 	}
 }

--- a/lib/svg-sprite.js
+++ b/lib/svg-sprite.js
@@ -88,6 +88,7 @@ SVGSpriter.prototype.add = function (file, name, svg) {
 	// If no vinyl file object has been given
 	if (!this._isVinylFile(file)) {
 		file = _.trim(file);
+		var error = null;
 
 		// If the name part of the file path is absolute
 		if (name && path.isAbsolute(name)) {
@@ -99,7 +100,6 @@ SVGSpriter.prototype.add = function (file, name, svg) {
 			svg = _.trim(svg);
 
 			// Argument validation
-			var error = null;
 			if (arguments.length < 3) {
 				error = 'SVGSpriter.add: You must provide 3 arguments';
 			}

--- a/lib/svg-sprite/mode/base.js
+++ b/lib/svg-sprite/mode/base.js
@@ -15,7 +15,6 @@ _									= require('lodash'),
 fs									= require('fs'),
 async								= require('async'),
 mustache							= require('mustache'),
-os 									= require('os'),
 File								= require('vinyl'),
 crypto								= require('crypto');
 

--- a/lib/svg-sprite/mode/symbol.js
+++ b/lib/svg-sprite/mode/symbol.js
@@ -62,7 +62,7 @@ SVGSpriteSymbol.prototype.layout = function(files, cb) {
 				});
 				removeAttributes.forEach(function(attribute){
 					shapeDOM.removeAttribute(attribute);
-				})
+				});
 				shapeDOM.setAttribute('id', shape.id);
 			});
 		});

--- a/lib/svg-sprite/queue.js
+++ b/lib/svg-sprite/queue.js
@@ -12,7 +12,6 @@
 
 var path				= require('path'),
 async					= require('async'),
-os						= require('os'),
 events					= require('events'),
 SHAPE					= require('./shape');
 

--- a/lib/svg-sprite/shape.js
+++ b/lib/svg-sprite/shape.js
@@ -38,7 +38,7 @@ createIdGenerator			= function(template) {
 	 * @param {File} file			Original vinyl file
 	 * @returns {String}			Shape ID
      */
-	var generator = function(name, file) {
+	var generator = function(name) {
 		return util.format(template || '%s', path.basename(name.split(path.sep).join(this.separator).replace(/\s+/g, this.whitespace), '.svg'));
 	};
 	return generator;

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "CHANGELOG.md"
   ],
   "scripts": {
+    "pretest": "npm run lint",
     "test": "istanbul test _mocha --report html -- test/*.js --reporter spec",
     "lint": "jshint bin && jshint lib && jshint test",
     "coveralls": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage"


### PR DESCRIPTION
Fixes JSHint errors that went uncaught. Adds linting as a `pretest` task, to avoid further errors.

I recommend switching from JSHint to ESLint and its `eslint:recommended` rules.