### PR TITLE
fix: use the mocha binary from node_modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   ],
   "scripts": {
     "pretest": "npm run lint",
-    "test": "istanbul test _mocha --report html -- test/*.js --reporter spec",
+    "test": "istanbul test node_modules/mocha/bin/_mocha --report html -- test/svg-sprite.js --reporter spec",
     "lint": "jshint bin && jshint lib && jshint test",
     "coveralls": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage"
   },


### PR DESCRIPTION
Currently the tests do not run on Windows due to an issue in instanbul loading the mocha binary.

This PR fixes it.

https://github.com/generalov/gemini/commit/255d8518ce30d53b55f170df5ea94687ac7e3cf1
https://github.com/gotwarlost/istanbul/issues/13
https://github.com/gotwarlost/istanbul/issues/90