### PR TITLE
replace legacy plugin name by respective one

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -177,7 +177,7 @@ To call a pre-defined transformation with custom configuration options, use it's
         transform: [
             {svgo: {
                 plugins: [
-                    {transformsWithOnePath: true},
+                    {convertShapeToPath: false},
                     {moveGroupAttrsToElems: false}
                 ]
             }}


### PR DESCRIPTION
Hi,

using this svgo plugin with svg-sprite according docs, I realized it's not working. So I figured out, this is an old reference. See https://github.com/svg/svgo/pull/980

Furthermore I set to false in this case to reflect you actually want to override the default.

Have a nice week
midzer