### PR TITLE
Nonexistent transformsWithOnePath plugin

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -177,7 +177,6 @@ To call a pre-defined transformation with custom configuration options, use it's
         transform: [
             {svgo: {
                 plugins: [
-                    {transformsWithOnePath: true},
                     {moveGroupAttrsToElems: false}
                 ]
             }}


### PR DESCRIPTION
This is also removed from the official svgo documentation

https://github.com/svg/svgo/commit/83548977eaf9683d586339b142befdcb949bff8a