### PR TITLE
Fix verbose logging output (closes #279)

### DIFF
--- a/lib/svg-sprite/config.js
+++ b/lib/svg-sprite/config.js
@@ -10,8 +10,6 @@
  * @license MIT https://raw.github.com/jkphl/svg-sprite/master/LICENSE
  */
 
-var dateFormat = require('dateformat');
-
 var _ = require('lodash'),
     path = require('path'),
     yaml = require('js-yaml'),
@@ -103,9 +101,7 @@ function SVGSpriterConfig(config) {
                 format: winston.format.combine(
                     winston.format.colorize(),
                     winston.format.timestamp({
-                        format: function (timestamp) {
-                            return dateFormat(timestamp, 'yyyy-mm-dd HH:MM:ss');
-                        }
+                        format: 'YYYY-MM-DD HH:MM:ss'
                     }),
                     winston.format.splat(),
                     winston.format.printf(function (info) {

--- a/lib/svg-sprite/config.js
+++ b/lib/svg-sprite/config.js
@@ -100,12 +100,18 @@ function SVGSpriterConfig(config) {
             transports: [new winston.transports.Console({
                 level: this.log || 'info',
                 silent: !this.log.length,
-                colorize: true,
-                prettyPrint: true,
-                timestamp: function () {
-                    var now = new Date();
-                    return dateFormat(now, 'yyyy-mm-dd HH:MM:ss');
-                }
+                format: winston.format.combine(
+                    winston.format.colorize(),
+                    winston.format.timestamp({
+                        format: function (timestamp) {
+                            return dateFormat(timestamp, 'yyyy-mm-dd HH:MM:ss');
+                        }
+                    }),
+                    winston.format.splat(),
+                    winston.format.printf(function (info) {
+                        return info.timestamp + ' - ' + info.level + ': ' + info.message;
+                    })
+                )
             })]
         });
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "svg-sprite",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -26,6 +26,7 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
+      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -677,11 +678,6 @@
       "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
       "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
       "dev": true
-    },
-    "dateformat": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
-      "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q=="
     },
     "debug": {
       "version": "2.6.9",
@@ -1830,6 +1826,7 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-buffer": "^1.1.5"
       }
@@ -2118,7 +2115,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "loud-rejection": {
       "version": "1.6.0",
@@ -3059,7 +3057,8 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "repeating": {
       "version": "2.0.1",
@@ -3148,11 +3147,11 @@
       }
     },
     "rimraf": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
       "requires": {
-        "glob": "^7.0.5"
+        "glob": "^7.1.3"
       }
     },
     "safe-buffer": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "css-selector-parser": "^1.3.0",
     "cssmin": "^0.4.3",
     "cssom": "^0.3.4",
-    "dateformat": "^3.0.3",
     "glob": "^7.1.3",
     "js-yaml": "^3.12.0",
     "lodash": "^4.17.11",


### PR DESCRIPTION
As I described in the issue (#279), the verbose logging broke with an upgrade to `winston@3.x.x`, which dramatically changed its formatting API. This PR restores the log output to the original output format.

One discovery I've found is that Winston's timestamp functionality accepts its own date formatting string, which means that the `dateformat` dependency specified in this package is not strictly necessary. I am also proposing to remove that here.