### PR TITLE
Escape hash sing built-in function

### DIFF
--- a/docs/templating.md
+++ b/docs/templating.md
@@ -221,6 +221,16 @@ Finds all backslashes in a string and escapes each of them with another backslas
 }
 ```
 
+#### encodeHashSign
+
+Finds all hash signs in a string and encodes each of them to `%23` symbol. 
+
+```css
+.{{name}}-background {
+  background: url('data:image/svg+xml;utf-8,{{#escapeHashSign}}{{{svg}}}{{/escapeHashSign}}') no-repeat;
+}
+```
+
 
 [npm-url]: https://npmjs.org/package/svg-sprite
 [npm-image]: https://badge.fury.io/js/svg-sprite.png

--- a/lib/svg-sprite/layouter.js
+++ b/lib/svg-sprite/layouter.js
@@ -76,6 +76,11 @@ defaultVariables                    = {
         return function(str, render) {
             return render(str).split('\\').join('\\\\');
         };
+    },
+    encodeHashSign                  : function() {
+        return function(str, render) {
+            return render(str).split('#').join('%23');
+        };
     }
 };
 


### PR DESCRIPTION
Creates an ability to generate scss file, which contains css classes such as 
.{{name}}-background {
  background: url('data:image/svg+xml;utf-8,{{#escapeHashSign}}{{{svg}}}{{/escapeHashSign}}') no-repeat;
}

Some svg-files contain hash signs ('#') which make it impossible to use such svg's as data urls. Url encoding of the whole file should work but It's not always suitable to increase generated file size. So I found it appropriate to encode only hash signs symbols. Using the library in cli mode makes it impossible to pass custom variables function to generator so it's the simplest way to deal with it. 