### PR TITLE
Upgrade mocha to avoid security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "istanbul": "*",
     "jshint": "^2.11.0",
     "less": "^3.10.3",
-    "mocha": "^7.0.0",
+    "mocha": "^7.1.0",
     "mocha-lcov-reporter": "*",
     "node-sass": "^4.13.1",
     "pn": "^1.1.0",


### PR DESCRIPTION
`mocha@7.1.0` doesn't have `mkdirp@0.5.1` as dependency. `mkdirp@0.5.1` depends of `minimist` prior to `v1.2.3`, version that have security vulnerability:

```
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ Low           │ Prototype Pollution                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ minimist                                                     │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=0.2.1 <1.0.0 || >=1.2.3                                    │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ svg-sprite [dev]                                             │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ svg-sprite > mocha > mkdirp > minimist                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/1179                            │
├───────────────┼──────────────────────────────────────────────────────────────┤
```