### PR TITLE
Revert "Replace `_.trim` with native"

### DIFF
--- a/lib/svg-sprite.js
+++ b/lib/svg-sprite.js
@@ -87,7 +87,7 @@ SVGSpriter.prototype.add = function (file, name, svg) {
 
     // If no vinyl file object has been given
     if (!this._isVinylFile(file)) {
-        file = file.trim();
+        file = _.trim(file);
         var error = null;
 
         // If the name part of the file path is absolute
@@ -96,8 +96,8 @@ SVGSpriter.prototype.add = function (file, name, svg) {
 
             // Else
         } else {
-            name = _.trimStart(name.trim(), path.sep + '.') || path.basename(file);
-            svg = svg.trim();
+            name = _.trimStart(_.trim(name), path.sep + '.') || path.basename(file);
+            svg = _.trim(svg);
 
             // Argument validation
             if (arguments.length < 3) {


### PR DESCRIPTION
Reverts jkphl/svg-sprite#408

`svg` seems to a buffer in one case. We should handle this more explicitly later so I'll revert this for now. Tests didn't catch this unfortunately...